### PR TITLE
Fix #10

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,54 +9,6 @@ For more about us, see [our page on the PSF wiki](https://wiki.python.org/psf/Pr
 This repository holds public resources for you to use:
 
 * [Available grants and similar funds](./funders.md)
-* [Budgeting and proposal writing links](./resources.md)
+* [Budgeting and proposal writing guides](./resources.md)
+* [Projects and example proposals](./projects.md)
 
-## Previously completed and in-progress projects
-
-### Dependency resolver and user experience improvements for `pip` (2020-present)
-* **Funder**: [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) and [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
-* **Amount funded**: $407,000 ($200,000 and $207,000 respectively)
-* **Team composition**: 1x project manager, 4x software engineer, 3x UX/UI engineer
-* **Context**:
-  * Design, implementation, and rollout of `pip`'s [next-generation dependency resolver](https://github.com/psf/fundable-packaging-improvements/blob/master/FUNDABLES.md#finish-dependency-resolver-for-pip).
-* **Links**:
-  * [PSF blog post about the grant](https://pyfound.blogspot.com/2019/12/moss-czi-support-pip.html)
-  * [Dependency resolver launch announcment](https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html)
-
-### Security features for PyPI (2019-present)
-* **Funder**: [Facebook Research](https://research.fb.com/)
-* **Amount funded**: $100,000
-* **Team composition**: 1x project manager, 2x software engineer
-* **Context**:
-  * Two-part project focused on:
-    * Malware work: Add features for malware detection to PyPI
-    * [PEP 485](https://www.python.org/dev/peps/pep-0458/) implementation for cryptographic signing of artifacts
-* **Links**:
-  * [Malware detection launch announcement](https://pyfound.blogspot.com/2020/03/an-update-pypi-funded-work.html)
-
-### PyPI Localization and Internationalization
-* **Funder**: [Open Technology Fund](https://www.opentech.fund/)
-* **Amount funded**: $80,000
-* **Team composition**: 1x project manager, 2x software engineer
-* **Context**:
-  * Implement & deploy security, localization, and accessibility improvements for PyPI's codebase
-    * Two-factor authentication
-    * API tokens
-    * Localization and translation support
-* **Links**:
-  * [Open Technology Fund announcement](https://www.opentech.fund/results/supported-projects/pypi-improvements/)
-  * [PSF blog post about the grant](http://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html)
-  * [2FA launch announcement](https://pyfound.blogspot.com/2019/06/pypi-now-supports-two-factor-login-via.html)
-  * [API token launch announcement](https://blog.python.org/2019/07/pypi-now-supports-uploading-via-api.html)
-
-### PyPI Rewrite / "Warehouse" rollout (2018)
-* **Funder**: [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
-* **Amount funded**: $170,000
-* **Team composition**: 1x project manager, 1x UI/UX engineer, 1x software engineer
-* **Context**:
-  * Finish implementation of a modern full-stack PyPI rewrite, and launch it as the Python Package Index.
-* **Links**:
-  * [Mozilla announcment](https://blog.mozilla.org/blog/2018/01/23/moss-q4-supporting-python-ecosystem/)
-  * [Mozilla-produced interview with project manager](https://www.youtube.com/watch?v=2j_dEEMMlBA)
-  * [PSF blog post about the grant](https://pyfound.blogspot.com/2017/11/the-psf-awarded-moss-grant-pypi.html)
-  * [PyPI launch announcement](https://blog.python.org/2018/04/new-pypi-launched-legacy-pypi-shutting.html)

--- a/projects.md
+++ b/projects.md
@@ -1,4 +1,4 @@
-# Projects
+# Prospective Projects
 
 The following list gathers potentially fundable project ideas within the Python ecosystem.
 
@@ -7,3 +7,58 @@ The following list gathers potentially fundable project ideas within the Python 
 - [BeeWare](https://github.com/beeware/beeware/pull/67)
 
 If you have have an idea for improving an area not covered on this list, open a Pull Request to this repository!
+
+# Previously completed and in-progress projects
+
+### Dependency resolver and user experience improvements for `pip` (2020-present)
+* **Funder**: [Chan Zuckerberg Initiative](https://chanzuckerberg.com/) and [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
+* **Amount funded**: $407,000 ($200,000 and $207,000 respectively)
+* **Team composition**: 1x project manager, 4x software engineer, 3x UX/UI engineer
+* **Context**:
+  * Design, implementation, and rollout of `pip`'s [next-generation dependency resolver](https://github.com/psf/fundable-packaging-improvements/blob/master/FUNDABLES.md#finish-dependency-resolver-for-pip).
+* **Links**:
+  * [PSF blog post about the grant](https://pyfound.blogspot.com/2019/12/moss-czi-support-pip.html)
+  * [Dependency resolver launch announcment](https://blog.python.org/2020/07/upgrade-pip-20-2-changes-20-3.html)
+  * [Original MOSS Proposal](https://drive.google.com/file/d/11Gz_5Up1YgU4SkJh564nZ4xSvoAvkNOM/view?usp=sharing)
+  * [Original CZI Proposal](https://drive.google.com/file/d/1E7EElvn0O7tFsRWjV6dATHZOVBqGaHHR/view?usp=sharing)
+
+### Security features for PyPI (2019-present)
+* **Funder**: [Facebook Research](https://research.fb.com/)
+* **Amount funded**: $100,000
+* **Team composition**: 1x project manager, 2x software engineer
+* **Context**:
+  * Two-part project focused on:
+    * Malware work: Add features for malware detection to PyPI
+    * [PEP 485](https://www.python.org/dev/peps/pep-0458/) implementation for cryptographic signing of artifacts
+* **Links**:
+  * [Malware detection launch announcement](https://pyfound.blogspot.com/2020/03/an-update-pypi-funded-work.html)
+
+### PyPI Localization and Internationalization
+* **Funder**: [Open Technology Fund](https://www.opentech.fund/)
+* **Amount funded**: $80,000
+* **Team composition**: 1x project manager, 2x software engineer
+* **Context**:
+  * Implement & deploy security, localization, and accessibility improvements for PyPI's codebase
+    * Two-factor authentication
+    * API tokens
+    * Localization and translation support
+* **Links**:
+  * [Open Technology Fund announcement](https://www.opentech.fund/results/supported-projects/pypi-improvements/)
+  * [PSF blog post about the grant](http://pyfound.blogspot.com/2019/03/commencing-security-accessibility-and.html)
+  * [2FA launch announcement](https://pyfound.blogspot.com/2019/06/pypi-now-supports-two-factor-login-via.html)
+  * [API token launch announcement](https://blog.python.org/2019/07/pypi-now-supports-uploading-via-api.html)
+  * [Original Proposal](https://drive.google.com/file/d/1vKwkjoXsE1YEYz77DkQFm8bOXMCKUp2j/view?usp=sharing)
+
+### PyPI Rewrite / "Warehouse" rollout (2018)
+* **Funder**: [Mozilla Open Source Support](https://www.mozilla.org/en-US/moss/)
+* **Amount funded**: $170,000
+* **Team composition**: 1x project manager, 1x UI/UX engineer, 1x software engineer
+* **Context**:
+  * Finish implementation of a modern full-stack PyPI rewrite, and launch it as the Python Package Index.
+* **Links**:
+  * [Mozilla announcment](https://blog.mozilla.org/blog/2018/01/23/moss-q4-supporting-python-ecosystem/)
+  * [Mozilla-produced interview with project manager](https://www.youtube.com/watch?v=2j_dEEMMlBA)
+  * [PSF blog post about the grant](https://pyfound.blogspot.com/2017/11/the-psf-awarded-moss-grant-pypi.html)
+  * [PyPI launch announcement](https://blog.python.org/2018/04/new-pypi-launched-legacy-pypi-shutting.html)
+  * [Original Proposal](https://docs.google.com/document/d/1XAaE7JEsBDPVMRzAn_3Vd8EDIOBeHirvm-3HGIxJf1s/edit?usp=sharing)
+  * [Revised Statement of Work](https://drive.google.com/file/d/1teOiGmqZHpkY6Qyj2inH3fOMPY5wAeLe/view?usp=sharing)


### PR DESCRIPTION
Move past and in-progress proposals to `proposals.md`. Add links to successful proposals.

This is simply a starting point for discussion. The links are currently only visible to members of the "PSF Project Funding Working Group" shared drive. These documents contain:
- Information about the proposer, and in one case, the proposer's CV (Ernest)
- Information about the PSF
- Detailed budgets and SoWs
- Information about contractors whose work  was/will be funded by the proposal(s)

What, if any, of the above information is considered sensitive and should be removed?

As far as how this will be organized internally, I can create a new directory in drive with the truncated proposals. Feedback welcome!